### PR TITLE
Integrate logging support with heartbeat structs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.9)
 
 project(heartbeats-simple)
-set(PROJECT_VERSION 0.1.0)
+set(PROJECT_VERSION 0.2.0)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wno-unknown-pragmas")
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)
@@ -64,7 +64,7 @@ target_link_libraries(hb-acc-pow-test hbs-acc-pow)
 
 set(PKG_CONFIG_EXEC_PREFIX "\${prefix}")
 set(PKG_CONFIG_LIBDIR "\${prefix}/lib")
-set(PKG_CONFIG_INCLUDEDIR "\${prefix}/include/heartbeats-simple")
+set(PKG_CONFIG_INCLUDEDIR "\${prefix}/include/${PROJECT_NAME}")
 set(PKG_CONFIG_CFLAGS "-I\${includedir}")
 
 set(PKG_CONFIG_NAME "heartbeats-simple")

--- a/example/hb-pow-example.c
+++ b/example/hb-pow-example.c
@@ -15,8 +15,7 @@
 
 // Callback function for when a window is complete (window buffer is full)
 void window_complete(const heartbeat_pow_context* hb) {
-  // we should log the data or else we'll lose it
-  hb_pow_log_window_buffer(hb, fileno(stdout));
+  // dummy function
 }
 
 // Simulate energy readings
@@ -49,6 +48,7 @@ int main(int argc, char** argv) {
   const int window_size = 5;
   uint64_t start_time, end_time;
   uint64_t start_energy, end_energy;
+  int fd = fileno(stdout);
 
   // Alternatively, a window buffer can be allocated on the stack with a
   // statically sized array - just don't let it go out of scope before
@@ -57,8 +57,8 @@ int main(int argc, char** argv) {
 
   // initialize heartbeat
   heartbeat_pow_context hb;
-  heartbeat_pow_init(&hb, window_size, window_buffer, &window_complete);
-  hb_pow_log_header(fileno(stdout));
+  heartbeat_pow_init(&hb, window_size, window_buffer, fd, &window_complete);
+  hb_pow_log_header(fd);
 
   // simple example - doesn't track heartbeat time/energy overhead
   for(i = 0; i < iterations; i++) {

--- a/inc/heartbeat-acc-pow.h
+++ b/inc/heartbeat-acc-pow.h
@@ -59,12 +59,14 @@ typedef struct heartbeat_acc_pow_context {
  * @param hb
  * @param window_size
  * @param window_buffer
+ * @param log_fd
  * @param hwc_callback
  * @return 0 on success, another value otherwise
  */
 int heartbeat_acc_pow_init(heartbeat_acc_pow_context* hb,
                            uint64_t window_size,
                            heartbeat_acc_pow_record* window_buffer,
+                           int log_fd,
                            heartbeat_acc_pow_window_complete* hwc_callback);
 
 /**
@@ -114,6 +116,14 @@ int hb_acc_pow_log_window_buffer(const heartbeat_acc_pow_context* hb, int fd);
  * @return the size of the sliding window (uint64_t)
  */
 uint64_t hb_acc_pow_get_window_size(const heartbeat_acc_pow_context* hb);
+
+/**
+ * Returns the log file descriptor
+ *
+ * @param hb pointer to heartbeat_t
+ * @return the log file descriptor (int)
+ */
+int hb_acc_pow_get_log_fd(const heartbeat_acc_pow_context* hb);
 
 /**
  * Returns the current user tag

--- a/inc/heartbeat-acc.h
+++ b/inc/heartbeat-acc.h
@@ -53,12 +53,14 @@ typedef struct heartbeat_acc_context {
  * @param hb
  * @param window_size
  * @param window_buffer
+ * @param log_fd
  * @param hwc_callback
  * @return 0 on success, another value otherwise
  */
 int heartbeat_acc_init(heartbeat_acc_context* hb,
                        uint64_t window_size,
                        heartbeat_acc_record* window_buffer,
+                       int log_fd,
                        heartbeat_acc_window_complete* hwc_callback);
 
 /**
@@ -104,6 +106,14 @@ int hb_acc_log_window_buffer(const heartbeat_acc_context* hb, int fd);
  * @return the size of the sliding window (uint64_t)
  */
 uint64_t hb_acc_get_window_size(const heartbeat_acc_context* hb);
+
+/**
+ * Returns the log file descriptor
+ *
+ * @param hb pointer to heartbeat_t
+ * @return the log file descriptor (int)
+ */
+int hb_acc_get_log_fd(const heartbeat_acc_context* hb);
 
 /**
  * Returns the current user tag

--- a/inc/heartbeat-common-types.h
+++ b/inc/heartbeat-common-types.h
@@ -27,6 +27,7 @@ typedef struct heartbeat_window_state {
   uint64_t buffer_index;
   uint64_t read_index;
   uint64_t window_size;
+  int log_fd;
 } heartbeat_window_state;
 
 #ifdef __cplusplus

--- a/inc/heartbeat-pow.h
+++ b/inc/heartbeat-pow.h
@@ -54,12 +54,14 @@ typedef struct heartbeat_pow_context {
  * @param hb
  * @param window_size
  * @param window_buffer
+ * @param log_fd
  * @param hwc_callback
  * @return 0 on success, another value otherwise
  */
 int heartbeat_pow_init(heartbeat_pow_context* hb,
                        uint64_t window_size,
                        heartbeat_pow_record* window_buffer,
+                       int log_fd,
                        heartbeat_pow_window_complete* hwc_callback);
 
 /**
@@ -106,6 +108,14 @@ int hb_pow_log_window_buffer(const heartbeat_pow_context* hb, int fd);
  * @return the size of the sliding window (uint64_t)
  */
 uint64_t hb_pow_get_window_size(const heartbeat_pow_context* hb);
+
+/**
+ * Returns the log file descriptor
+ *
+ * @param hb pointer to heartbeat_t
+ * @return the log file descriptor (int)
+ */
+int hb_pow_get_log_fd(const heartbeat_pow_context* hb);
 
 /**
  * Returns the current user tag

--- a/inc/heartbeat.h
+++ b/inc/heartbeat.h
@@ -47,12 +47,14 @@ typedef struct heartbeat_context {
  * @param hb
  * @param window_size
  * @param window_buffer
+ * @param log_fd
  * @param hwc_callback
  * @return 0 on success, another value otherwise
  */
 int heartbeat_init(heartbeat_context* hb,
                    uint64_t window_size,
                    heartbeat_record* window_buffer,
+                   int log_fd,
                    heartbeat_window_complete* hwc_callback);
 
 /**
@@ -95,6 +97,14 @@ int hb_log_window_buffer(const heartbeat_context* hb, int fd);
  * @return the size of the sliding window (uint64_t)
  */
 uint64_t hb_get_window_size(const heartbeat_context* hb);
+
+/**
+ * Returns the log file descriptor
+ *
+ * @param hb pointer to heartbeat_t
+ * @return the log file descriptor (int)
+ */
+int hb_get_log_fd(const heartbeat_context* hb);
 
 /**
  * Returns the current user tag

--- a/src/hb-util.c
+++ b/src/hb-util.c
@@ -32,6 +32,18 @@ uint64_t hb_get_window_size(const heartbeat_context* hb) {
 }
 
 #if defined(HEARTBEAT_MODE_ACC)
+int hb_acc_get_log_fd(const heartbeat_acc_context* hb) {
+#elif defined(HEARTBEAT_MODE_POW)
+int hb_pow_get_log_fd(const heartbeat_pow_context* hb) {
+#elif defined(HEARTBEAT_MODE_ACC_POW)
+int hb_acc_pow_get_log_fd(const heartbeat_acc_pow_context* hb) {
+#else
+int hb_get_log_fd(const heartbeat_context* hb) {
+#endif
+  return hb == NULL ? -1 : hb->ws.log_fd;
+}
+
+#if defined(HEARTBEAT_MODE_ACC)
 uint64_t hb_acc_get_user_tag(const heartbeat_acc_context* hb) {
 #elif defined(HEARTBEAT_MODE_POW)
 uint64_t hb_pow_get_user_tag(const heartbeat_pow_context* hb) {

--- a/test/hb-acc-pow-test.c
+++ b/test/hb-acc-pow-test.c
@@ -9,12 +9,13 @@ int main(int argc, char** argv) {
   uint64_t window_size = 20;
   heartbeat_acc_pow_context hb;
   heartbeat_acc_pow_record* window_buffer = malloc(window_size * sizeof(heartbeat_acc_pow_record));
-  heartbeat_acc_pow_init(&hb, window_size, window_buffer, NULL);
+  heartbeat_acc_pow_init(&hb, window_size, window_buffer, -1, NULL);
   heartbeat_acc_pow(&hb, 0, 1, 0, 1000000000, 1, 0, 1000000);
   hb_acc_pow_log_header(1);
   hb_acc_pow_log_window_buffer(&hb, 1);
 
   hb_acc_pow_get_window_size(&hb);
+  hb_acc_pow_get_log_fd(&hb);
   hb_acc_pow_get_user_tag(&hb);
   hb_acc_pow_get_global_time(&hb);
   hb_acc_pow_get_window_time(&hb);

--- a/test/hb-acc-test.c
+++ b/test/hb-acc-test.c
@@ -9,12 +9,13 @@ int main(int argc, char** argv) {
   uint64_t window_size = 20;
   heartbeat_acc_context hb;
   heartbeat_acc_record* window_buffer = malloc(window_size * sizeof(heartbeat_acc_record));
-  heartbeat_acc_init(&hb, window_size, window_buffer, NULL);
+  heartbeat_acc_init(&hb, window_size, window_buffer, -1, NULL);
   heartbeat_acc(&hb, 0, 1, 0, 1000000000, 1);
   hb_acc_log_header(1);
   hb_acc_log_window_buffer(&hb, 1);
 
   hb_acc_get_window_size(&hb);
+  hb_acc_get_log_fd(&hb);
   hb_acc_get_user_tag(&hb);
   hb_acc_get_global_time(&hb);
   hb_acc_get_window_time(&hb);

--- a/test/hb-pow-test.c
+++ b/test/hb-pow-test.c
@@ -9,12 +9,13 @@ int main(int argc, char** argv) {
   uint64_t window_size = 20;
   heartbeat_pow_context hb;
   heartbeat_pow_record* window_buffer = malloc(window_size * sizeof(heartbeat_pow_record));
-  heartbeat_pow_init(&hb, window_size, window_buffer, NULL);
+  heartbeat_pow_init(&hb, window_size, window_buffer, -1, NULL);
   heartbeat_pow(&hb, 0, 1, 0, 1000000000, 0, 1000000);
   hb_pow_log_header(1);
   hb_pow_log_window_buffer(&hb, 1);
 
   hb_pow_get_window_size(&hb);
+  hb_pow_get_log_fd(&hb);
   hb_pow_get_user_tag(&hb);
   hb_pow_get_global_time(&hb);
   hb_pow_get_window_time(&hb);

--- a/test/hb-test.c
+++ b/test/hb-test.c
@@ -9,12 +9,13 @@ int main(int argc, char** argv) {
   uint64_t window_size = 20;
   heartbeat_context hb;
   heartbeat_record* window_buffer = malloc(window_size * sizeof(heartbeat_record));
-  heartbeat_init(&hb, window_size, window_buffer, NULL);
+  heartbeat_init(&hb, window_size, window_buffer, -1, NULL);
   heartbeat(&hb, 0, 1, 0, 1000000000);
   hb_log_header(1);
   hb_log_window_buffer(&hb, 1);
 
   hb_get_window_size(&hb);
+  hb_get_log_fd(&hb);
   hb_get_user_tag(&hb);
   hb_get_global_time(&hb);
   hb_get_window_time(&hb);


### PR DESCRIPTION
This work breaks the existing interface by adding a new file descriptor field to the common `heartbeat_window_state` struct and a new parameter to the `init` functions.

On a window completion, the data is logged if the provided file descriptor is valid.
